### PR TITLE
Bypassing call to driver::BuildCompilation by providing arguments to …

### DIFF
--- a/mlir-clang/CMakeLists.txt
+++ b/mlir-clang/CMakeLists.txt
@@ -69,3 +69,6 @@ target_link_libraries(mlir-clang PRIVATE
 )
 add_dependencies(mlir-clang MLIRPolygeistOpsIncGen MLIRPolygeistPassIncGen)
 add_subdirectory(Test)
+add_custom_command(TARGET mlir-clang POST_BUILD
+	COMMAND mv $<TARGET_FILE:mlir-clang> ${CLANG_DIR}/../../../bin/mlir-clang
+	COMMENT "Moved mlir-clang to ${CLANG_DIR}/../../../bin/")

--- a/mlir-clang/Lib/clang-mlir.cc
+++ b/mlir-clang/Lib/clang-mlir.cc
@@ -5526,11 +5526,6 @@ bool MLIRASTConsumer::HandleTopLevelDecl(DeclGroupRef dg) {
       continue;
     }
 
-    if (fd->getIdentifier())
-       llvm::errs() << "Func name: " << fd->getName() << "\n";
-     llvm::errs() << "Func Body && Loc " << "\n";
-     fd->getBody()->dump();
-     fd->getLocation().dump(SM);
 
     bool externLinkage = true;
     /*
@@ -6082,7 +6077,8 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
                       std::string fn, std::vector<std::string> includeDirs,
                       std::vector<std::string> defines,
                       mlir::OwningOpRef<mlir::ModuleOp> &module,
-                      llvm::Triple &triple, llvm::DataLayout &DL) {
+                      llvm::Triple &triple, llvm::DataLayout &DL,
+                      std::vector<std::string> InputCommandArgs) {
 
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
   // Buffer diagnostics from argument parsing so that we can output them using a
@@ -6162,27 +6158,39 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
 
   Argv.push_back("-emit-ast");
 
-  const unique_ptr<Compilation> compilation(
-      driver->BuildCompilation(llvm::ArrayRef<const char *>(Argv)));
+
+  llvm::SmallVector<const ArgStringList *, 4> CommandList;
+  ArgStringList InputCommandArgList;
+
+  unique_ptr<Compilation> compilation;
+
+  if (InputCommandArgs.empty()) {
+    compilation.reset(
+      std::move(driver->BuildCompilation(llvm::ArrayRef<const char *>(Argv))));
+
   JobList &Jobs = compilation->getJobs();
   if (Jobs.size() < 1)
     return false;
-
-  MLIRAction Act(fn, module);
-
   for (auto &job : Jobs) {
-    std::unique_ptr<CompilerInstance> Clang(new CompilerInstance());
-
     Command *cmd = cast<Command>(&job);
     if (strcmp(cmd->getCreator().getName(), "clang"))
       return false;
+      CommandList.push_back(&cmd->getArguments());
+   }
+  }
+  else {
+    for (std::string& s : InputCommandArgs) {
+      InputCommandArgList.push_back(s.c_str());
+    }
+    CommandList.push_back(&InputCommandArgList);
+  }
 
-    const ArgStringList *args = &cmd->getArguments();
+  MLIRAction Act(fn, module);
 
-    llvm::SmallVector<const char*, 16> args2 = {"-cc1", "-triple", "spir64-unknown-unknown", "-aux-triple", "x86_64-unknown-linux-gnu", "-fsycl-is-device", "-fdeclare-spirv-builtins", "-mllvm", "-sycl-opt", "-Wno-sycl-strict", "-fsycl-int-header=/tmp/no-loop-header-c4ae95.h", "-fsycl-int-footer=/tmp/no-loop-footer-572676.h", "-sycl-std=2020", "-fsycl-unique-prefix=02926462a8d9f0f8", "-Wspir-compat", "-emit-llvm", "-emit-llvm-uselists", "-disable-free", "-main-file-name", "-mrelocation-model", "static", "-mframe-pointer=all", "-fmath-errno", "-fno-rounding-math", "-fno-verbose-asm", "-mconstructor-aliases", "-aux-target-cpu", "x86-64", "-debugger-tuning=gdb", "-fcoverage-compilation-dir=/home/mahmoud/codeplay/Polygeist/llvm-project/build/test", "-resource-dir", "/home/mahmoud/codeplay/Polygeist/llvm-project/build/lib/clang/14.0.0", "-internal-isystem", "/home/mahmoud/codeplay/Polygeist/llvm-project/build/test/../bin/../include/sycl", "-internal-isystem", "/home/mahmoud/codeplay/Polygeist/llvm-project/build/test/../bin/../include", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/x86_64-linux-gnu/c++/9", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/backward", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/x86_64-linux-gnu/c++/9", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/backward", "-internal-isystem", "/home/mahmoud/codeplay/Polygeist/llvm-project/build/lib/clang/14.0.0/include", "-internal-isystem", "/usr/local/include", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../x86_64-linux-gnu/include", "-internal-externc-isystem", "/usr/include/x86_64-linux-gnu", "-internal-externc-isystem", "/include", "-internal-externc-isystem", "/usr/include", "-internal-isystem", "/home/mahmoud/codeplay/Polygeist/llvm-project/build/lib/clang/14.0.0/include", "-internal-isystem", "/usr/local/include", "-internal-isystem", "/usr/lib/gcc/x86_64-linux-gnu/9/../../../../x86_64-linux-gnu/include", "-internal-externc-isystem", "/usr/include/x86_64-linux-gnu", "-internal-externc-isystem", "/include", "-internal-externc-isystem", "/usr/include", "-std=c++17", "-fdeprecated-macro", "-fdebug-compilation-dir=/home/mahmoud/codeplay/Polygeist/llvm-project/build/test", "-ferror-limit", "19", "-fgnuc-version=4.2.1", "-fcxx-exceptions", "-fexceptions", "-fcolor-diagnostics", "-faddrsig", "-D__GCC_HAVE_DWARF2_CFI_ASM=1", "-o", "/tmp/no-loop-c59c82.bc", "-x", "c++",
-    "-D__x86_64__", "-DDISABLE_SYCL_INSTRUMENTATION_METADATA"};
+  for (const ArgStringList *args : CommandList) {
+    std::unique_ptr<CompilerInstance> Clang(new CompilerInstance());
 
-    Success = CompilerInvocation::CreateFromArgs(Clang->getInvocation(), args2,
+    Success = CompilerInvocation::CreateFromArgs(Clang->getInvocation(), *args,
                                                   Diags);
     Clang->getInvocation().getFrontendOpts().DisableFree = false;
 
@@ -6214,7 +6222,7 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
       return false;
 
     // Create TargetInfo for the other side of CUDA and OpenMP compilation.
-    if ((Clang->getLangOpts().CUDA || Clang->getLangOpts().OpenMPIsDevice) &&
+    if ((Clang->getLangOpts().CUDA || Clang->getLangOpts().OpenMPIsDevice || Clang->getLangOpts().SYCLIsDevice) &&
         !Clang->getFrontendOpts().AuxTriple.empty()) {
       auto TO = std::make_shared<clang::TargetOptions>();
       TO->Triple = llvm::Triple::normalize(Clang->getFrontendOpts().AuxTriple);
@@ -6242,14 +6250,13 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
         StringAttr::get(module->getContext(),
                         Clang->getTarget().getTriple().getTriple()));
 
-//    for (const auto &FIF : Clang->getFrontendOpts().Inputs)
+    for (const auto &FIF : Clang->getFrontendOpts().Inputs)
     {
       // Reset the ID tables if we are reusing the SourceManager and parsing
       // regular files.
       if (Clang->hasSourceManager() && !Act.isModelParsingAction())
         Clang->getSourceManager().clearIDTables();
 
-      auto FIF = FrontendInputFile(Argv[1], FrontendOptions::getInputKindForExtension("cpp"));
       if (Act.BeginSourceFile(*Clang, FIF)) {
 
         llvm::Error err = Act.Execute();

--- a/mlir-clang/Lib/clang-mlir.cc
+++ b/mlir-clang/Lib/clang-mlir.cc
@@ -6168,17 +6168,16 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
     compilation.reset(
       std::move(driver->BuildCompilation(llvm::ArrayRef<const char *>(Argv))));
 
-  JobList &Jobs = compilation->getJobs();
-  if (Jobs.size() < 1)
-    return false;
-  for (auto &job : Jobs) {
-    Command *cmd = cast<Command>(&job);
-    if (strcmp(cmd->getCreator().getName(), "clang"))
+    JobList &Jobs = compilation->getJobs();
+    if (Jobs.size() < 1)
       return false;
+    for (auto &job : Jobs) {
+      Command *cmd = cast<Command>(&job);
+      if (strcmp(cmd->getCreator().getName(), "clang"))
+        return false;
       CommandList.push_back(&cmd->getArguments());
-   }
-  }
-  else {
+    }
+  } else {
     for (std::string& s : InputCommandArgs) {
       InputCommandArgList.push_back(s.c_str());
     }
@@ -6250,15 +6249,13 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
         StringAttr::get(module->getContext(),
                         Clang->getTarget().getTriple().getTriple()));
 
-    for (const auto &FIF : Clang->getFrontendOpts().Inputs)
-    {
+    for (const auto &FIF : Clang->getFrontendOpts().Inputs) {
       // Reset the ID tables if we are reusing the SourceManager and parsing
       // regular files.
       if (Clang->hasSourceManager() && !Act.isModelParsingAction())
         Clang->getSourceManager().clearIDTables();
 
       if (Act.BeginSourceFile(*Clang, FIF)) {
-
         llvm::Error err = Act.Execute();
         if (err) {
           llvm::errs() << "saw error: " << err << "\n";

--- a/mlir-clang/mlir-clang.cc
+++ b/mlir-clang/mlir-clang.cc
@@ -97,10 +97,6 @@ static cl::opt<std::string> CUDAPath("cuda-path", cl::init(""),
 
 static cl::opt<std::string> Output("o", cl::init("-"), cl::desc("Output file"));
 
-static cl::list<std::string> inputFileName(cl::Positional, cl::OneOrMore,
-                                           cl::desc("<Specify input file>"),
-                                           cl::cat(toolOptions));
-
 static cl::opt<std::string> cfunction("function",
                                       cl::desc("<Specify function>"),
                                       cl::init("main"), cl::cat(toolOptions));
@@ -132,6 +128,12 @@ static cl::list<std::string> includeDirs("I", cl::desc("include search path"),
 
 static cl::list<std::string> defines("D", cl::desc("defines"),
                                      cl::cat(toolOptions));
+
+static cl::list<std::string> inputFileName(cl::Positional, cl::OneOrMore,
+                                           cl::desc("<Specify input file>"),
+                                           cl::cat(toolOptions));
+
+cl::list<std::string>  inputCommandArgs(cl::ConsumeAfter, cl::desc("<command arguments>"));
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
@@ -399,7 +401,8 @@ int main(int argc, char **argv) {
   llvm::Triple triple;
   llvm::DataLayout DL("");
   parseMLIR(argv[0], inputFileName, cfunction, includeDirs, defines, module,
-            triple, DL);
+            triple, DL, inputCommandArgs);
+
   mlir::PassManager pm(&context);
 
   if (ImmediateMLIR) {


### PR DESCRIPTION
1- Gets rid of hardcoded arguments needed to process SYCL.
2- Allows passing the Command arguments after input SYCL file.
3- Moves mlir-clang binary to where clang is. This is needed, otherwise Polygeist won't be able to find proper paths to SYCL headers.