### PR TITLE
Moadeli/process sycl kernels

### DIFF
--- a/mlir-clang/Lib/clang-mlir.cc
+++ b/mlir-clang/Lib/clang-mlir.cc
@@ -5526,6 +5526,11 @@ bool MLIRASTConsumer::HandleTopLevelDecl(DeclGroupRef dg) {
       continue;
     }
 
+    // if (fd->getIdentifier())
+    //    llvm::errs() << "Func name: " << fd->getName() << "\n";
+    //  llvm::errs() << "Func Body && Loc " << "\n";
+    //  fd->getBody()->dump();
+    //  fd->getLocation().dump(SM);
 
     bool externLinkage = true;
     /*
@@ -5561,7 +5566,8 @@ bool MLIRASTConsumer::HandleTopLevelDecl(DeclGroupRef dg) {
 
     if ((emitIfFound.count("*") && name != "fpclassify" && !fd->isStatic() &&
          externLinkage) ||
-        emitIfFound.count(name)) {
+        emitIfFound.count(name) ||
+        fd->hasAttr<SYCLHalideAttr>()) {
       functionsToEmit.push_back(fd);
     } else {
     }
@@ -6168,13 +6174,13 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
     compilation.reset(
       std::move(driver->BuildCompilation(llvm::ArrayRef<const char *>(Argv))));
 
-  JobList &Jobs = compilation->getJobs();
-  if (Jobs.size() < 1)
-    return false;
-  for (auto &job : Jobs) {
-    Command *cmd = cast<Command>(&job);
-    if (strcmp(cmd->getCreator().getName(), "clang"))
-      return false;
+    JobList &Jobs = compilation->getJobs();
+    if (Jobs.size() < 1)
+     return false;
+    for (auto &job : Jobs) {
+      Command *cmd = cast<Command>(&job);
+      if (strcmp(cmd->getCreator().getName(), "clang"))
+        return false;
       CommandList.push_back(&cmd->getArguments());
    }
   }

--- a/mlir-clang/Lib/clang-mlir.cc
+++ b/mlir-clang/Lib/clang-mlir.cc
@@ -5526,11 +5526,6 @@ bool MLIRASTConsumer::HandleTopLevelDecl(DeclGroupRef dg) {
       continue;
     }
 
-    // if (fd->getIdentifier())
-    //    llvm::errs() << "Func name: " << fd->getName() << "\n";
-    //  llvm::errs() << "Func Body && Loc " << "\n";
-    //  fd->getBody()->dump();
-    //  fd->getLocation().dump(SM);
 
     bool externLinkage = true;
     /*
@@ -6176,11 +6171,13 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
 
     JobList &Jobs = compilation->getJobs();
     if (Jobs.size() < 1)
-     return false;
+      return false;
     for (auto &job : Jobs) {
       Command *cmd = cast<Command>(&job);
+      
       if (strcmp(cmd->getCreator().getName(), "clang"))
         return false;
+
       CommandList.push_back(&cmd->getArguments());
    }
   }

--- a/mlir-clang/mlir-clang.cc
+++ b/mlir-clang/mlir-clang.cc
@@ -302,6 +302,8 @@ int emitBinary(char *Argv0, const char *filename,
 #include "Lib/clang-mlir.cc"
 int main(int argc, char **argv) {
 
+  bool syclKernelsOnly = false;
+  
   if (argc >= 1) {
     if (std::string(argv[1]) == "-cc1") {
       SmallVector<const char *> Argv;
@@ -338,6 +340,9 @@ int main(int argc, char **argv) {
         } else if (ref.startswith("-I")) {
           MLIRArgs.push_back("-I");
           MLIRArgs.push_back(&argv[i][2]);
+        } else if (ref == "-fintel-halide") {
+          syclKernelsOnly = true;
+          MLIRArgs.push_back(argv[i]);
         } else {
           MLIRArgs.push_back(argv[i]);
         }
@@ -400,9 +405,16 @@ int main(int argc, char **argv) {
 
   llvm::Triple triple;
   llvm::DataLayout DL("");
-  parseMLIR(argv[0], inputFileName, cfunction, includeDirs, defines, module,
-            triple, DL, inputCommandArgs);
 
+  std::string fn;
+
+  if (!syclKernelsOnly)
+  {
+    fn = cfunction.getValue();
+  }
+  
+  parseMLIR(argv[0], inputFileName, fn, includeDirs, defines, module,
+            triple, DL, inputCommandArgs);
   mlir::PassManager pm(&context);
 
   if (ImmediateMLIR) {


### PR DESCRIPTION
- Enables processing only SYCL kernels annotated with [intel::halide] if `-fintel-halide` is passed as an argument.
- Minor style fixes.

