### PR TITLE
remove inputCommandArgs as they're currently unused

### DIFF
--- a/tools/mlir-clang/mlir-clang.cc
+++ b/tools/mlir-clang/mlir-clang.cc
@@ -136,7 +136,7 @@ static cl::list<std::string> inputFileName(cl::Positional, cl::OneOrMore,
                                            cl::desc("<Specify input file>"),
                                            cl::cat(toolOptions));
 
-static cl::list<std::string>  inputCommandArgs(cl::ConsumeAfter, cl::desc("<command arguments>"));
+static cl::list<std::string>  inputCommandArgs("args", cl::Positional, cl::desc("<command arguments>"), cl::ZeroOrMore, cl::PositionalEatsArgs);
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 


### PR DESCRIPTION
Removing the command line arg which takes `cl::ConsumeAfter`, currently this doesn't seem to be used in the `parseMLIR` function.