### PR TITLE
Enable building unified with LLVM and set submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "llvm-project"]
 	path = llvm-project
-	url = https://github.com/llvm/llvm-project.git
+	url = git@github.com:InteonCo/sycl_integration.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ Polygeist can also be built as an external LLVM project using [LLVM_EXTERNAL_PRO
 mkdir build
 cd build
 cmake -G Ninja ../llvm-project/llvm \
-  -DLLVM_ENABLE_PROJECTS="clang;mlir" \
-  -DLLVM_EXTERNAL_PROJECTS="polygeist" \
+  -DLLVM_ENABLE_PROJECTS="clang;mlir;opencl;sycl" \
+  -DLLVM_EXTERNAL_PROJECTS="polygeist;opencl;sycl" \
   -DLLVM_EXTERNAL_POLYGEIST_SOURCE_DIR=.. \
+  -DLLVM_EXTERNAL_SYCL_SOURCE_DIR=../llvm-project/sycl \
   -DLLVM_TARGETS_TO_BUILD="host" \
   -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DSYCL_HALIDE_PATH=<path to halide> \
   -DCMAKE_BUILD_TYPE=DEBUG
 ninja
 ninja check-mlir-clang

--- a/tools/mlir-clang/CMakeLists.txt
+++ b/tools/mlir-clang/CMakeLists.txt
@@ -74,7 +74,3 @@ target_link_libraries(mlir-clang PRIVATE
 )
 add_dependencies(mlir-clang MLIRPolygeistOpsIncGen MLIRPolygeistPassIncGen)
 add_subdirectory(Test)
-add_custom_command(TARGET mlir-clang POST_BUILD
-	COMMAND mv $<TARGET_FILE:mlir-clang> ${CLANG_DIR}/../../../bin/mlir-clang
-	COMMENT "Moved mlir-clang to ${CLANG_DIR}/../../../bin/")
-


### PR DESCRIPTION
The changes are:
- Setting the submodule to our fork of dpc++, including updating to the latest commit
- Make `mlir-clang` buildable unified with LLVM
To make this happen I had to remove the command which moves `mlir-clang` binary. `sycl-headers` and `clang` were added as dependencies to `mlir-clang` for required headers to be available, this can be removed if it's deemed too much, original Polygeist doesn't have this even though it would require some headers which would be available when building `clang`, therefore I'm not sure if adding these dependencies is the right way to go.
Lastly instructions have been added to the README to build Polygeist unified with LLVM. I haven't changed the other build instructions since I haven't tried this method of building yet.

edit: I have not made sycl-headers and clang a dependency for mlir-clang, it didn't seem to be the correct thing to do just to get headers available automatically