### PR TITLE
[MLIR][SYCL] Generate SYCLConstructorOp instead of CallOp

### DIFF
--- a/tools/mlir-clang/Lib/CGCall.cc
+++ b/tools/mlir-clang/Lib/CGCall.cc
@@ -311,6 +311,12 @@ ValueCategory MLIRScanner::CallHelper(
   // Try to rescue some mismatched types.
   castCallerArgs(tocall, args, builder);
 
+  /// Try to emit SYCL operations instead of creating a CallOp
+  const auto ValEmitted = EmitSYCLOps(expr, args);
+  if (ValEmitted.second) {
+    return ValEmitted.first;
+  }
+
   auto op = builder.create<mlir::CallOp>(loc, tocall, args);
 
   if (isArrayReturn) {
@@ -1455,7 +1461,12 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     return ValueCategory(called, isReference);
   }
 
-  auto tocall = EmitDirectCallee(callee);
+  /// If the callee is part of the SYCL namespace, we do not want the
+  /// GetOrCreateMLIRFunction to add this FuncOp to the functionsToEmit dequeu,
+  /// since we will create it's equivalent with SYCL operations.
+  auto ShouldEmit =
+      !mlirclang::isNamespaceSYCL(callee->getEnclosingNamespaceContext());
+  auto ToCall = Glob.GetOrCreateMLIRFunction(callee, ShouldEmit);
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> args;
   QualType objType;
@@ -1478,6 +1489,6 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   }
   for (auto a : expr->arguments())
     args.push_back(make_pair(Visit(a), a));
-  return CallHelper(tocall, objType, args, expr->getType(),
+  return CallHelper(ToCall, objType, args, expr->getType(),
                     expr->isLValue() || expr->isXValue(), expr);
 }

--- a/tools/mlir-clang/Lib/clang-mlir.h
+++ b/tools/mlir-clang/Lib/clang-mlir.h
@@ -98,7 +98,8 @@ struct MLIRASTConsumer : public ASTConsumer {
 
   ~MLIRASTConsumer() {}
 
-  mlir::FuncOp GetOrCreateMLIRFunction(const FunctionDecl *FD);
+  mlir::FuncOp GetOrCreateMLIRFunction(const FunctionDecl *FD,
+                                       const bool ShouldEmit = true);
 
   mlir::LLVM::LLVMFuncOp GetOrCreateLLVMFunction(const FunctionDecl *FD);
   mlir::LLVM::LLVMFuncOp GetOrCreateMallocFunction();
@@ -284,6 +285,10 @@ public:
   std::pair<ValueCategory, bool> EmitGPUCallExpr(clang::CallExpr *expr);
 
   std::pair<ValueCategory, bool> EmitBuiltinOps(clang::CallExpr *expr);
+
+  std::pair<ValueCategory, bool>
+  EmitSYCLOps(const clang::Expr *Expr,
+              const llvm::SmallVectorImpl<mlir::Value> &Args);
 
   ValueCategory
   VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *expr);

--- a/tools/mlir-clang/Lib/utils.cc
+++ b/tools/mlir-clang/Lib/utils.cc
@@ -57,3 +57,23 @@ mlirclang::replaceFuncByOperation(FuncOp f, StringRef opName, OpBuilder &b,
                          f.getCallableResults(), {});
   return b.createOperation(opState);
 }
+
+bool mlirclang::isNamespaceSYCL(const clang::DeclContext *DC) {
+  if (!DC) {
+    return false;
+  }
+
+  if (const auto *ND = dyn_cast<clang::NamespaceDecl>(DC)) {
+    if (const auto *II = ND->getIdentifier()) {
+      if (II->isStr("sycl")) {
+        return true;
+      }
+    }
+  }
+
+  if (DC->getParent()) {
+    return mlirclang::isNamespaceSYCL(DC->getParent());
+  }
+
+  return false;
+}

--- a/tools/mlir-clang/Lib/utils.h
+++ b/tools/mlir-clang/Lib/utils.h
@@ -10,6 +10,8 @@
 #define MLIR_TOOLS_MLIRCLANG_UTILS_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "clang/AST/DeclBase.h"
+#include "llvm/ADT/APInt.h"
 
 namespace mlir {
 class Operation;
@@ -42,6 +44,8 @@ replaceFuncByOperation(mlir::FuncOp f, llvm::StringRef opName,
                        mlir::OpBuilder &b,
                        llvm::SmallVectorImpl<mlir::Value> &input,
                        llvm::SmallVectorImpl<mlir::Value> &output);
+
+bool isNamespaceSYCL(const clang::DeclContext *DC);
 } // namespace mlirclang
 
 #endif

--- a/tools/mlir-clang/mlir-clang.cc
+++ b/tools/mlir-clang/mlir-clang.cc
@@ -458,9 +458,9 @@ int main(int argc, char **argv) {
   bool LinkOMP = FOpenMP;
   pm.enableVerifier(EarlyVerifier);
   mlir::OpPassManager &optPM = pm.nest<mlir::FuncOp>();
-  // JLE_QUEL::FIXME
-  // Mem2RegPass is failing at this point
-  // Fix it, then revert condition to be true
+  /// JLE_QUEL::FIXME
+  /// Mem2RegPass is failing at this point - II-199
+  /// Fix it, then revert condition to be true
   if (false) {
     optPM.addPass(mlir::createCSEPass());
     optPM.addPass(mlir::createCanonicalizerPass());


### PR DESCRIPTION
This PR introduces the first step to replacing all calls to the SYCL API, with their SYCL dialect-operations equivalent.
This first step is to replace ```CallOp``` to function by ```SYCLConstructorOp``` - In order to do that, we need to check if this ```CXXConstructorDecl``` is part of the sycl namespace, if that's the case, we can then generate the sycl operations.

An operand called ```ShouldEmit``` has been added to the ```::getOrCreateMLIRFunction```, this is used because we still want to create a ```FuncOp```, in order to use the path created by Polygeist to check if the arguments are similar to what is being seen in the AST and other checks, but we don't want to add it to the ```FunctionToEmit``` dequeue (and generate that function).
