### PR TITLE
[MLIR][SYCL] Replace memref cast by sycl cast op when casting sycl derive type to sycl base type

### DIFF
--- a/tools/mlir-clang/Lib/CGCall.cc
+++ b/tools/mlir-clang/Lib/CGCall.cc
@@ -1464,8 +1464,12 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   /// If the callee is part of the SYCL namespace, we do not want the
   /// GetOrCreateMLIRFunction to add this FuncOp to the functionsToEmit dequeu,
   /// since we will create it's equivalent with SYCL operations.
-  auto ShouldEmit =
-      !mlirclang::isNamespaceSYCL(callee->getEnclosingNamespaceContext());
+  auto ShouldEmit = true;
+  /// JLE_QUEL::FIXME
+  /// When starting to work on II-209 and II-210, remove ShouldEmit = true
+  /// and uncomment ShouldEmit = !mlirclang:: ...
+  // auto ShouldEmit =
+  // !mlirclang::isNamespaceSYCL(callee->getEnclosingNamespaceContext());
   auto ToCall = Glob.GetOrCreateMLIRFunction(callee, ShouldEmit);
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> args;

--- a/tools/mlir-clang/Lib/clang-mlir.cc
+++ b/tools/mlir-clang/Lib/clang-mlir.cc
@@ -1841,14 +1841,7 @@ MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
             Cons->getConstructor()->getEnclosingNamespaceContext())) {
       if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(
               Cons->getConstructor()->getParent())) {
-        auto op = builder.create<mlir::sycl::SYCLConstructorOp>(
-            loc, RD->getName(), Args);
-        /// JLE_QUEL::FIXME
-        /// Until II-213 is fixed, keep verifying "locally". Then we'll be
-        /// able to remove it
-        if (mlir::failed(op.verify())) {
-          llvm_unreachable("verifier failed");
-        }
+        builder.create<mlir::sycl::SYCLConstructorOp>(loc, RD->getName(), Args);
         return make_pair(nullptr, true);
       }
     }
@@ -3268,6 +3261,23 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
       auto ty = mlir::MemRefType::get(mt.getShape(), mt.getElementType(),
                                       MemRefLayoutAttrInterface(),
                                       ut.getMemorySpace());
+      if (ty.getElementType().getDialect().getNamespace() ==
+          mlir::sycl::SYCLDialect::getDialectNamespace()) {
+        if (ut.getElementType().getDialect().getNamespace() ==
+            mlir::sycl::SYCLDialect::getDialectNamespace()) {
+          if (ty.getElementType() != ut.getElementType()) {
+            return ValueCategory(
+                builder.create<mlir::sycl::SYCLCastOp>(loc, ty, se.val),
+                /*isReference*/ se.isReference);
+          }
+        }
+      }
+
+      /// JLE_QUEL::THOUGHT
+      /// This logic should never be executed since the integration of the sycl
+      /// dialect is the only one to use memref on struct type.
+      /// Keep this unreachable until we have re-enabled testing.
+      llvm_unreachable("");
       return ValueCategory(
           builder.create<mlir::memref::CastOp>(loc, se.val, ty),
           /*isReference*/ se.isReference);

--- a/tools/mlir-clang/Lib/clang-mlir.cc
+++ b/tools/mlir-clang/Lib/clang-mlir.cc
@@ -1849,13 +1849,17 @@ MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
     if (mlirclang::isNamespaceSYCL(Ope->getCalleeDecl()
                                        ->getAsFunction()
                                        ->getEnclosingNamespaceContext())) {
-      llvm_unreachable("not implemented");
+      /// JLE_QUEL::FIXME
+      /// When starting to work on II-209 and II-210, uncomment unreachable
+      // llvm_unreachable("not implemented");
     }
   } else if (const auto *Ope = dyn_cast<clang::CXXMemberCallExpr>(Expr)) {
     if (mlirclang::isNamespaceSYCL(Ope->getCalleeDecl()
                                        ->getAsFunction()
                                        ->getEnclosingNamespaceContext())) {
-      llvm_unreachable("not implemented");
+      /// JLE_QUEL::FIXME
+      /// When starting to work on II-209 and II-210, uncomment unreachable
+      // llvm_unreachable("not implemented");
     }
   }
 
@@ -3262,15 +3266,13 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
                                       MemRefLayoutAttrInterface(),
                                       ut.getMemorySpace());
       if (ty.getElementType().getDialect().getNamespace() ==
-          mlir::sycl::SYCLDialect::getDialectNamespace()) {
-        if (ut.getElementType().getDialect().getNamespace() ==
-            mlir::sycl::SYCLDialect::getDialectNamespace()) {
-          if (ty.getElementType() != ut.getElementType()) {
-            return ValueCategory(
-                builder.create<mlir::sycl::SYCLCastOp>(loc, ty, se.val),
-                /*isReference*/ se.isReference);
-          }
-        }
+              mlir::sycl::SYCLDialect::getDialectNamespace() &&
+          ut.getElementType().getDialect().getNamespace() ==
+              mlir::sycl::SYCLDialect::getDialectNamespace() &&
+          ty.getElementType() != ut.getElementType()) {
+        return ValueCategory(
+            builder.create<mlir::sycl::SYCLCastOp>(loc, ty, se.val),
+            /*isReference*/ se.isReference);
       }
 
       /// JLE_QUEL::THOUGHT

--- a/tools/mlir-clang/mlir-clang.cc
+++ b/tools/mlir-clang/mlir-clang.cc
@@ -455,6 +455,12 @@ int main(int argc, char **argv) {
     llvm::errs() << "</immediate: mlir>\n";
   }
 
+  if (mlir::failed(mlir::verify(module.get()))) {
+    module->emitError("Verifier failed");
+    module->dump();
+    return 5;
+  }
+
   bool LinkOMP = FOpenMP;
   pm.enableVerifier(EarlyVerifier);
   mlir::OpPassManager &optPM = pm.nest<mlir::FuncOp>();


### PR DESCRIPTION
This PR introduces the usage of the new sycl cast operation.
It also enables the verifier on the output module before applying any optimization pass.

The sycl cast operation is used when a CastExpr is visiting the CK_UncheckedDerivedToBase case.
This is replaced because using the memref cast will create a verifier error since memref is not aware of sycl types and their inheritance.