### PR TITLE
[MLIR][SYCL] Generate sycl CallOp instead of standard CallOp

### DIFF
--- a/tools/mlir-clang/Lib/CGCall.cc
+++ b/tools/mlir-clang/Lib/CGCall.cc
@@ -312,11 +312,8 @@ ValueCategory MLIRScanner::CallHelper(
   castCallerArgs(tocall, args, builder);
 
   /// Try to emit SYCL operations before creating a CallOp
-  mlir::Operation *op = nullptr;
-  const auto ValEmitted = EmitSYCLOps(expr, args);
-  if (ValEmitted.second) {
-    op = ValEmitted.first;
-  } else {
+  mlir::Operation *op = EmitSYCLOps(expr, args);
+  if (!op) {
     op = builder.create<mlir::CallOp>(loc, tocall, args);
   }
 

--- a/tools/mlir-clang/Lib/clang-mlir.cc
+++ b/tools/mlir-clang/Lib/clang-mlir.cc
@@ -1833,11 +1833,10 @@ MLIRScanner::EmitGPUCallExpr(clang::CallExpr *expr) {
   return make_pair(ValueCategory(), false);
 }
 
-std::pair<mlir::Operation *, bool>
+mlir::Operation *
 MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
                          const llvm::SmallVectorImpl<mlir::Value> &Args) {
   mlir::Operation *Op = nullptr;
-  bool Res = false;
 
   if (const auto *ConsExpr = dyn_cast<clang::CXXConstructExpr>(Expr)) {
     const auto *Func = ConsExpr->getConstructor()->getAsFunction();
@@ -1846,7 +1845,6 @@ MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
       if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent())) {
         Op = builder.create<mlir::sycl::SYCLConstructorOp>(loc, RD->getName(),
                                                            Args);
-        Res = true;
       }
     }
   } else if (const auto *CallExpr = dyn_cast<clang::CallExpr>(Expr)) {
@@ -1873,11 +1871,10 @@ MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
 
       Op = builder.create<mlir::sycl::SYCLCallOp>(
           loc, OptRetType, OptFuncType, Func->getNameAsString(), Args);
-      Res = true;
     }
   }
 
-  return make_pair(Op, Res);
+  return Op;
 }
 
 mlir::Value MLIRScanner::getConstantIndex(int x) {

--- a/tools/mlir-clang/Lib/clang-mlir.h
+++ b/tools/mlir-clang/Lib/clang-mlir.h
@@ -286,7 +286,7 @@ public:
 
   std::pair<ValueCategory, bool> EmitBuiltinOps(clang::CallExpr *expr);
 
-  std::pair<ValueCategory, bool>
+  std::pair<mlir::Operation *, bool>
   EmitSYCLOps(const clang::Expr *Expr,
               const llvm::SmallVectorImpl<mlir::Value> &Args);
 

--- a/tools/mlir-clang/Lib/clang-mlir.h
+++ b/tools/mlir-clang/Lib/clang-mlir.h
@@ -286,9 +286,8 @@ public:
 
   std::pair<ValueCategory, bool> EmitBuiltinOps(clang::CallExpr *expr);
 
-  std::pair<mlir::Operation *, bool>
-  EmitSYCLOps(const clang::Expr *Expr,
-              const llvm::SmallVectorImpl<mlir::Value> &Args);
+  mlir::Operation *EmitSYCLOps(const clang::Expr *Expr,
+                               const llvm::SmallVectorImpl<mlir::Value> &Args);
 
   ValueCategory
   VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *expr);


### PR DESCRIPTION
This PR finalizes the work that has been started by this [Generate sycl constructor op PR](https://github.com/InteonCo/Polygeist/pull/13).

In addition to generating sycl constructor op when the callee is a ```CXXConstructExpr```. This PR generate a sycl call op when the expression is a ```CallExpr```, which encapsulates all calls to member functions as well as calls to "standard" functions respecting that the callee is part of the sycl namespace
