### PR TITLE
[MLIR][SYCL] Replace condition to create sycl MLIR type

### DIFF
--- a/tools/mlir-clang/Lib/clang-mlir.cc
+++ b/tools/mlir-clang/Lib/clang-mlir.cc
@@ -4741,9 +4741,9 @@ mlir::Type MLIRASTConsumer::getMLIRType(clang::QualType qt, bool *implicitRef,
       }
     }
 
-    if (mlirclang::isNamespaceSYCL(
-            RT->getDecl()->getEnclosingNamespaceContext())) {
-      const auto TypeName = RT->getAsRecordDecl()->getName();
+    const auto *RD = RT->getAsRecordDecl();
+    if (mlirclang::isNamespaceSYCL(RD->getEnclosingNamespaceContext())) {
+      const auto TypeName = RD->getName();
       if (TypeName == "range" || TypeName == "array" || TypeName == "id" ||
           TypeName == "accessor" || TypeName == "AccessorImplDevice" ||
           TypeName == "item" || TypeName == "ItemBase" ||


### PR DESCRIPTION
Small PR for replacing the condition to create sycl MLIR type
It's better to rely on the namespace's name where the clang::RecordType has been declared to know if it's a sycl type, rather than by name matching ```.struct``` and ```.class```.