### PR TITLE
[SYCL][TEST] Fix sycl test driver

### DIFF
--- a/tools/mlir-clang/sycl-clang.py.in
+++ b/tools/mlir-clang/sycl-clang.py.in
@@ -16,7 +16,7 @@ def main():
     clang_args.extend(sys.argv[1:])
     clang_res = subprocess.Popen(clang_args, stderr=subprocess.PIPE)
     output = clang_res.stderr.readlines()
-    expanded_clang_args = output[4].decode("utf-8")
+    expanded_clang_args = output[6].decode("utf-8")
     split_output = shlex.split(expanded_clang_args)
 
     mlir_args = [mlir_tool, "-S", "--function=main", arg_file, "--args"]


### PR DESCRIPTION
This PR fixes the sycl test driver script that is used to run the sycl test, due to the re-organization of clang driver's actions