### PR TITLE
[SYCL][TEST] Update sycl tests with type aliases

### DIFF
--- a/tools/mlir-clang/Test/sycl/constructors.cpp
+++ b/tools/mlir-clang/Test/sycl/constructors.cpp
@@ -12,16 +12,19 @@
 
 #include <sycl/sycl.hpp>
 
+// CHECK: !sycl_id_2_ = type !sycl.id<2>
+// CHECK: !sycl_item_2_1_ = type !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+
 // CHECK: func @_Z6cons_1v() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %false = arith.constant false
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl.id<2>>) -> !llvm.ptr<i8>
-// CHECK-NEXT: %3 = "polygeist.typeSize"() {source = !sycl.id<2>} : () -> index
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<i8>
+// CHECK-NEXT: %3 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
 // CHECK-NEXT: %4 = arith.index_cast %3 : index to i64
 // CHECK-NEXT: "llvm.intr.memset"(%2, %c0_i8, %4, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
-// CHECK-NEXT: sycl.constructor(%1) {Type = @id} : (memref<?x!sycl.id<2>>) -> ()
+// CHECK-NEXT: sycl.constructor(%1) {Type = @id} : (memref<?x!sycl_id_2_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -30,9 +33,9 @@
 }
 
 // CHECK: func @_Z6cons_2mm(%arg0: i64, %arg1: i64) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {Type = @id} : (memref<?x!sycl.id<2>>, i64, i64) -> ()
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {Type = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -40,13 +43,13 @@
   auto id = sycl::id<2>{a, b};
 }
 
-// CHECK: func @_Z6cons_3N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl.item<2, 1>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl.item<2, 1>>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl.item<2, 1>> to memref<?x!sycl.item<2, 1>>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl.item<2, 1>>
-// CHECK-NEXT: sycl.constructor(%1, %3) {Type = @id} : (memref<?x!sycl.id<2>>, memref<?x!sycl.item<2, 1>>) -> ()
+// CHECK: func @_Z6cons_3N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: sycl.constructor(%1, %3) {Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_item_2_1_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -54,13 +57,13 @@
   auto id = sycl::id<2>{val};
 }
 
-// CHECK: func @_Z6cons_4N2cl4sycl2idILi2EEE(%arg0: !sycl.id<2>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl.id<2>>
-// CHECK-NEXT: sycl.constructor(%1, %3) {Type = @id} : (memref<?x!sycl.id<2>>, memref<?x!sycl.id<2>>) -> ()
+// CHECK: func @_Z6cons_4N2cl4sycl2idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: sycl.constructor(%1, %3) {Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 

--- a/tools/mlir-clang/Test/sycl/functions.cpp
+++ b/tools/mlir-clang/Test/sycl/functions.cpp
@@ -12,12 +12,16 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK: func @_Z8method_1N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl.item<2, 1>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK: !sycl_array_2_ = type !sycl.array<[2], (memref<2xi64>)>
+// CHECK: !sycl_id_2_ = type !sycl.id<2>
+// CHECK: !sycl_item_2_1_ = type !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+
+// CHECK: func @_Z8method_1N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.item<2, 1>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.item<2, 1>> to memref<?x!sycl.item<2, 1>>
-// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl.item<2, 1>>
-// CHECK-NEXT: %2 = sycl.call(%1, %c0_i32) {Function = @get_id, Type = @item} : (memref<?x!sycl.item<2, 1>>, i32) -> i64
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %2 = sycl.call(%1, %c0_i32) {Function = @get_id, Type = @item} : (memref<?x!sycl_item_2_1_>, i32) -> i64
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -25,11 +29,11 @@
   auto id = item.get_id(0);
 }
 
-// CHECK: func @_Z8method_2N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl.item<2, 1>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.item<2, 1>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.item<2, 1>> to memref<?x!sycl.item<2, 1>>
-// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl.item<2, 1>>
-// CHECK-NEXT: %2 = sycl.call(%1, %1) {Function = @"operator==", Type = @item} : (memref<?x!sycl.item<2, 1>>, memref<?x!sycl.item<2, 1>>) -> i8
+// CHECK: func @_Z8method_2N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %2 = sycl.call(%1, %1) {Function = @"operator==", Type = @item} : (memref<?x!sycl_item_2_1_>, memref<?x!sycl_item_2_1_>) -> i8
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -37,16 +41,16 @@
   auto id = item.operator==(item);
 }
 
-// CHECK: func @_Z4op_1N2cl4sycl2idILi2EEES2_(%arg0: !sycl.id<2>, %arg1: !sycl.id<2>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl.id<2>>
-// CHECK-NEXT: affine.store %arg1, %0[0] : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %4 = sycl.cast(%3) : (memref<?x!sycl.id<2>>) -> memref<?x!sycl.array<2>>
-// CHECK-NEXT: %5 = sycl.cast(%1) : (memref<?x!sycl.id<2>>) -> memref<?x!sycl.array<2>>
-// CHECK-NEXT: %6 = sycl.call(%4, %5) {Function = @"operator==", Type = @array} : (memref<?x!sycl.array<2>>, memref<?x!sycl.array<2>>) -> i8
+// CHECK: func @_Z4op_1N2cl4sycl2idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg1, %0[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %4 = sycl.cast(%3) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_array_2_>
+// CHECK-NEXT: %5 = sycl.cast(%1) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_array_2_>
+// CHECK-NEXT: %6 = sycl.call(%4, %5) {Function = @"operator==", Type = @array} : (memref<?x!sycl_array_2_>, memref<?x!sycl_array_2_>) -> i8
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -54,15 +58,15 @@
   auto id = a == b;
 }
 
-// CHECK: func @_Z8static_1N2cl4sycl2idILi2EEES2_(%arg0: !sycl.id<2>, %arg1: !sycl.id<2>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func @_Z8static_1N2cl4sycl2idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl.id<2>> to memref<?x!sycl.id<2>>
-// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %2 = sycl.cast(%1) : (memref<?x!sycl.id<2>>) -> memref<?x!sycl.array<2>>
-// CHECK-NEXT: %3 = sycl.call(%2, %c0_i32) {Function = @get, Type = @array} : (memref<?x!sycl.array<2>>, i32) -> i64
-// CHECK-NEXT: %4 = sycl.call(%2, %c1_i32) {Function = @get, Type = @array} : (memref<?x!sycl.array<2>>, i32) -> i64
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %2 = sycl.cast(%1) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_array_2_>
+// CHECK-NEXT: %3 = sycl.call(%2, %c0_i32) {Function = @get, Type = @array} : (memref<?x!sycl_array_2_>, i32) -> i64
+// CHECK-NEXT: %4 = sycl.call(%2, %c1_i32) {Function = @get, Type = @array} : (memref<?x!sycl_array_2_>, i32) -> i64
 // CHECK-NEXT: %5 = arith.addi %3, %4 : i64
 // CHECK-NEXT: %6 = sycl.call(%5) {Function = @abs} : (i64) -> i64
 // CHECK-NEXT: return

--- a/tools/mlir-clang/Test/sycl/kernels.cpp
+++ b/tools/mlir-clang/Test/sycl/kernels.cpp
@@ -12,7 +12,13 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK: func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) attributes {SYCLKernel = "_ZTS8kernel_1", llvm.linkage = #llvm.linkage<weak_odr>}
+// CHECK: !sycl_accessor_1_i32_read_write_global_buffer = type !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK: !sycl_id_1_ = type !sycl.id<1>
+// CHECK: !sycl_item_1_1_ = type !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
+// CHECK: !sycl_item_2_1_ = type !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+// CHECK: !sycl_range_1_ = type !sycl.range<1>
+
+// CHECK: func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) attributes {SYCLKernel = "_ZTS8kernel_1", llvm.linkage = #llvm.linkage<weak_odr>}
 // CHECK-NOT: SYCLKernel =
 
 class kernel_1 {
@@ -40,7 +46,7 @@ void host_1() {
   }
 }
 
-// CHECK: func @_ZTSZZ6host_2vENKUlRN2cl4sycl7handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) attributes {SYCLKernel = "_ZTSZZ6host_2vENKUlRN2cl4sycl7handlerEE_clES2_E8kernel_2", llvm.linkage = #llvm.linkage<weak_odr>}
+// CHECK: func @_ZTSZZ6host_2vENKUlRN2cl4sycl7handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) attributes {SYCLKernel = "_ZTSZZ6host_2vENKUlRN2cl4sycl7handlerEE_clES2_E8kernel_2", llvm.linkage = #llvm.linkage<weak_odr>}
 // CHECK-NOT: SYCLKernel =
 
 void host_2() {

--- a/tools/mlir-clang/Test/sycl/types.cpp
+++ b/tools/mlir-clang/Test/sycl/types.cpp
@@ -12,58 +12,73 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK: func @_Z4id_1N2cl4sycl2idILi1EEE(%arg0: !sycl.id<1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: !sycl_accessor_1_i32_read_write_global_buffer = type !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK: !sycl_accessor_2_i32_read_write_global_buffer = type !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK: !sycl_array_1_ = type !sycl.array<[1], (memref<1xi64>)>
+// CHECK: !sycl_array_2_ = type !sycl.array<[2], (memref<2xi64>)>
+// CHECK: !sycl_group_1_ = type !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
+// CHECK: !sycl_group_2_ = type !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+// CHECK: !sycl_id_1_ = type !sycl.id<1>
+// CHECK: !sycl_id_2_ = type !sycl.id<2>
+// CHECK: !sycl_item_1_1_ = type !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
+// CHECK: !sycl_item_2_0_ = type !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>
+// CHECK: !sycl_nd_item_1_ = type !sycl.nd_item<[1], (!sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>)>, !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>)>
+// CHECK: !sycl_nd_item_2_ = type !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>, !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>, !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>)>
+// CHECK: !sycl_range_1_ = type !sycl.range<1>
+// CHECK: !sycl_range_2_ = type !sycl.range<2>
+
+// CHECK: func @_Z4id_1N2cl4sycl2idILi1EEE(%arg0: !sycl_id_1_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void id_1(sycl::id<1> id) {}
 
-// CHECK: func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl.id<2>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void id_2(sycl::id<2> id) {}
 
-// CHECK: func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl.accessor<1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_read_write_global_buffer) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void acc_1(sycl::accessor<cl::sycl::cl_int, 1, sycl::access::mode::read_write>) {}
 
-// CHECK: func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl.accessor<2>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_read_write_global_buffer) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void acc_2(sycl::accessor<cl::sycl::cl_int, 2, sycl::access::mode::read_write>) {}
 
-// CHECK: func @_Z7range_1N2cl4sycl5rangeILi1EEE(%arg0: !sycl.range<1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z7range_1N2cl4sycl5rangeILi1EEE(%arg0: !sycl_range_1_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void range_1(sycl::range<1> range) {}
 
-// CHECK: func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl.range<2>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl_range_2_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void range_2(sycl::range<2> range) {}
 
-// CHECK: func @_Z5arr_1N2cl4sycl6detail5arrayILi1EEE(%arg0: !sycl.array<1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z5arr_1N2cl4sycl6detail5arrayILi1EEE(%arg0: !sycl_array_1_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void arr_1(sycl::detail::array<1> arr) {}
 
-// CHECK: func @_Z5arr_2N2cl4sycl6detail5arrayILi2EEE(%arg0: !sycl.array<2>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z5arr_2N2cl4sycl6detail5arrayILi2EEE(%arg0: !sycl_array_2_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void arr_2(sycl::detail::array<2> arr) {}
 
-// CHECK: func @_Z11item_1_trueN2cl4sycl4itemILi1ELb1EEE(%arg0: !sycl.item<1, 1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z11item_1_trueN2cl4sycl4itemILi1ELb1EEE(%arg0: !sycl_item_1_1_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void item_1_true(sycl::item<1, true> item) {}
 
-// CHECK: func @_Z12item_2_falseN2cl4sycl4itemILi2ELb0EEE(%arg0: !sycl.item<2, 0>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z12item_2_falseN2cl4sycl4itemILi2ELb0EEE(%arg0: !sycl_item_2_0_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void item_2_false(sycl::item<2, false> item) {}
 
-// CHECK: func @_Z9nd_item_1N2cl4sycl7nd_itemILi1EEE(%arg0: !sycl.nd_item<1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z9nd_item_1N2cl4sycl7nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void nd_item_1(sycl::nd_item<1> nd_item) {}
 
-// CHECK: func @_Z9nd_item_2N2cl4sycl7nd_itemILi2EEE(%arg0: !sycl.nd_item<2>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z9nd_item_2N2cl4sycl7nd_itemILi2EEE(%arg0: !sycl_nd_item_2_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void nd_item_2(sycl::nd_item<2> nd_item) {}
 
-// CHECK: func @_Z7group_1N2cl4sycl5groupILi1EEE(%arg0: !sycl.group<1>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z7group_1N2cl4sycl5groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void group_1(sycl::group<1> group) {}
 
-// CHECK: func @_Z7group_2N2cl4sycl5groupILi2EEE(%arg0: !sycl.group<2>) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK: func @_Z7group_2N2cl4sycl5groupILi2EEE(%arg0: !sycl_group_2_) attributes {llvm.linkage = #llvm.linkage<external>}
 
 [[intel::halide]] void group_2(sycl::group<2> group) {}


### PR DESCRIPTION
Because of the latest change within the sycl dialect (type aliases), the sycl tests were failing.
This PR addresses that problem.